### PR TITLE
feat: split read_bytes into cancel-safe and non-cancel-safe parts

### DIFF
--- a/src/encryption_provider/mod.rs
+++ b/src/encryption_provider/mod.rs
@@ -252,6 +252,12 @@ pub struct EncryptionProvider<State, const IS_SERVER: bool> {
     update_policy: UpdatePolicy,
 }
 
+impl<State, const IS_SERVER: bool> EncryptionProvider<State, IS_SERVER> {
+    pub fn state(&self) -> &State {
+        &self.state
+    }
+}
+
 impl<const IS_SERVER: bool> EncryptionProvider<UnprotectedHandshakeState, IS_SERVER> {
     pub fn new_from_stream(
         socket: TcpStream,

--- a/src/encryption_provider/mod.rs
+++ b/src/encryption_provider/mod.rs
@@ -113,6 +113,14 @@ impl ProtectedChannels {
 
 pub struct ProtectedHandshakeState {
     channels: ProtectedChannels,
+    session_id: Option<Uuid>,
+}
+
+impl ProtectedHandshakeState {
+    /// Session ID negotiated during the handshake, if any was negotiated.
+    pub fn session_id(&self) -> Option<Uuid> {
+        self.session_id
+    }
 }
 
 #[trait_variant::make(Send)]
@@ -242,7 +250,6 @@ pub struct EncryptionProvider<State, const IS_SERVER: bool> {
     state: State,
     address: String,
     update_policy: UpdatePolicy,
-    per_handshake_session_id: Option<Uuid>,
 }
 
 impl<const IS_SERVER: bool> EncryptionProvider<UnprotectedHandshakeState, IS_SERVER> {
@@ -259,7 +266,6 @@ impl<const IS_SERVER: bool> EncryptionProvider<UnprotectedHandshakeState, IS_SER
             state,
             address,
             update_policy,
-            per_handshake_session_id: None,
         })
     }
 
@@ -272,7 +278,7 @@ impl<const IS_SERVER: bool> EncryptionProvider<UnprotectedHandshakeState, IS_SER
         let address = socket.peer_addr()?.to_string();
         let (mut reader, mut writer) = TcpStream::into_split(socket);
 
-        let (pre_hs_secret, session_id) = if IS_SERVER {
+        let payload = if IS_SERVER {
             pre_handshake
                 .server_handshake(&mut reader, &mut writer)
                 .await
@@ -283,7 +289,7 @@ impl<const IS_SERVER: bool> EncryptionProvider<UnprotectedHandshakeState, IS_SER
         }
         .map_err(|e| EncryptionProviderError::PreHandshakeError(e.into()))?;
 
-        let traffic_secrets = derive_traffic_secrets(&pre_hs_secret)?;
+        let traffic_secrets = derive_traffic_secrets(&payload.shared_secret)?;
 
         let channels = ProtectedChannels::new::<IS_SERVER>(
             FramedRead::new(reader, TlsFrameCodec),
@@ -291,22 +297,18 @@ impl<const IS_SERVER: bool> EncryptionProvider<UnprotectedHandshakeState, IS_SER
             traffic_secrets,
         )?;
 
-        let state = ProtectedHandshakeState { channels };
+        let state = ProtectedHandshakeState {
+            channels,
+            session_id: payload.session_id,
+        };
 
         let provider = EncryptionProvider {
             state,
             address,
             update_policy,
-            per_handshake_session_id: Some(session_id),
         };
 
         Ok(provider)
-    }
-}
-
-impl<const IS_SERVER: bool> EncryptionProvider<ProtectedHandshakeState, IS_SERVER> {
-    pub fn pre_handshake_session_id(&self) -> Option<Uuid> {
-        self.per_handshake_session_id
     }
 }
 
@@ -328,7 +330,6 @@ impl<State: PreHandshakeState> EncryptionProvider<State, true> {
             },
             address: self.address,
             update_policy: self.update_policy,
-            per_handshake_session_id: None,
         };
 
         Ok((next_state, client_identity))
@@ -357,7 +358,6 @@ impl<State: PreHandshakeState> EncryptionProvider<State, false> {
             },
             address: self.address,
             update_policy: self.update_policy,
-            per_handshake_session_id: None,
         };
 
         Ok(next_state)

--- a/src/encryption_provider/mod.rs
+++ b/src/encryption_provider/mod.rs
@@ -30,7 +30,7 @@ use uuid::Uuid;
 
 use crate::{
     handshake::{ClientIdentity, CompletedHandshake, Handshake},
-    mls_handshake::{ClientHandshakeState, HandshakeError, MlsHandshake, MlsHandshakeError},
+    mls_handshake::{HandshakeError, MlsHandshake, MlsHandshakeError},
     pre_handshake::{derive_traffic_secrets, PreHandshake},
     tls_aead::{
         codec::TlsFrameCodec,
@@ -343,12 +343,6 @@ impl<State: PreHandshakeState> EncryptionProvider<State, false> {
         client_id: Uuid,
         server_verifying_key: &[u8],
     ) -> Result<EncryptionProvider<EstablishedState, false>, EncryptionProviderError> {
-        {
-            // TODO: This is a hack to delete the handshake state from the database
-            let mut connection = connection.lock().await;
-            ClientHandshakeState::delete(&mut connection, client_id)
-                .map_err(MlsHandshakeError::HandshakeError)?;
-        }
         let mut handshake = MlsHandshake::new(connection, leaf_signer);
 
         let channels = self

--- a/src/encryption_provider/mod.rs
+++ b/src/encryption_provider/mod.rs
@@ -30,7 +30,7 @@ use uuid::Uuid;
 
 use crate::{
     handshake::{ClientIdentity, CompletedHandshake, Handshake},
-    mls_handshake::{HandshakeError, MlsHandshake, MlsHandshakeError},
+    mls_handshake::{ClientHandshakeState, HandshakeError, MlsHandshake, MlsHandshakeError},
     pre_handshake::{derive_traffic_secrets, PreHandshake},
     tls_aead::{
         codec::TlsFrameCodec,
@@ -242,6 +242,7 @@ pub struct EncryptionProvider<State, const IS_SERVER: bool> {
     state: State,
     address: String,
     update_policy: UpdatePolicy,
+    per_handshake_session_id: Option<Uuid>,
 }
 
 impl<const IS_SERVER: bool> EncryptionProvider<UnprotectedHandshakeState, IS_SERVER> {
@@ -258,6 +259,7 @@ impl<const IS_SERVER: bool> EncryptionProvider<UnprotectedHandshakeState, IS_SER
             state,
             address,
             update_policy,
+            per_handshake_session_id: None,
         })
     }
 
@@ -270,7 +272,7 @@ impl<const IS_SERVER: bool> EncryptionProvider<UnprotectedHandshakeState, IS_SER
         let address = socket.peer_addr()?.to_string();
         let (mut reader, mut writer) = TcpStream::into_split(socket);
 
-        let pre_hs_secret = if IS_SERVER {
+        let (pre_hs_secret, session_id) = if IS_SERVER {
             pre_handshake
                 .server_handshake(&mut reader, &mut writer)
                 .await
@@ -295,9 +297,16 @@ impl<const IS_SERVER: bool> EncryptionProvider<UnprotectedHandshakeState, IS_SER
             state,
             address,
             update_policy,
+            per_handshake_session_id: Some(session_id),
         };
 
         Ok(provider)
+    }
+}
+
+impl<const IS_SERVER: bool> EncryptionProvider<ProtectedHandshakeState, IS_SERVER> {
+    pub fn pre_handshake_session_id(&self) -> Option<Uuid> {
+        self.per_handshake_session_id
     }
 }
 
@@ -319,6 +328,7 @@ impl<State: PreHandshakeState> EncryptionProvider<State, true> {
             },
             address: self.address,
             update_policy: self.update_policy,
+            per_handshake_session_id: None,
         };
 
         Ok((next_state, client_identity))
@@ -333,6 +343,12 @@ impl<State: PreHandshakeState> EncryptionProvider<State, false> {
         client_id: Uuid,
         server_verifying_key: &[u8],
     ) -> Result<EncryptionProvider<EstablishedState, false>, EncryptionProviderError> {
+        {
+            // TODO: This is a hack to delete the handshake state from the database
+            let mut connection = connection.lock().await;
+            ClientHandshakeState::delete(&mut connection, client_id)
+                .map_err(MlsHandshakeError::HandshakeError)?;
+        }
         let mut handshake = MlsHandshake::new(connection, leaf_signer);
 
         let channels = self
@@ -347,6 +363,7 @@ impl<State: PreHandshakeState> EncryptionProvider<State, false> {
             },
             address: self.address,
             update_policy: self.update_policy,
+            per_handshake_session_id: None,
         };
 
         Ok(next_state)
@@ -398,6 +415,38 @@ impl<const IS_SERVER: bool> EncryptionProvider<EstablishedState, IS_SERVER> {
                 None => {
                     return Ok(None);
                 }
+            }
+        }
+    }
+
+    /// Cancel-safe
+    pub async fn read_message(
+        &mut self,
+    ) -> Result<Option<InnerPlaintext>, EncryptionProviderError> {
+        self.next().await.transpose()
+    }
+
+    /// Not cancel-safe
+    pub async fn process_read_message(
+        &mut self,
+        message: InnerPlaintext,
+    ) -> Result<Option<Vec<u8>>, EncryptionProviderError> {
+        match message {
+            InnerPlaintext::Application(b) => Ok(Some(b)),
+            InnerPlaintext::Signaling(signaling_message) => {
+                let (secret_update, response) = self
+                    .state
+                    .handshake
+                    .process_signaling_message(&signaling_message)
+                    .await?;
+                if let Some(signaling_message) = response {
+                    self.send(InnerPlaintext::Signaling(signaling_message))
+                        .await?;
+                }
+                if let Some(secret_update) = secret_update {
+                    self.update_cipher(secret_update)?;
+                }
+                Ok(None)
             }
         }
     }

--- a/src/mls_handshake/mod.rs
+++ b/src/mls_handshake/mod.rs
@@ -8,7 +8,7 @@ use openmls_rust_crypto::RustCrypto;
 use openmls_sqlite_storage::{Codec, Connection, SqliteStorageProvider};
 use openmls_traits::OpenMlsProvider;
 use state_machine::{
-    client::{ClientHandshake, ClientHandshakeState},
+    client::ClientHandshake,
     initialize_storage,
     server::{ServerHandshake, ServerHandshakeState},
 };
@@ -24,6 +24,8 @@ use crate::{
     tls_aead::{codec::TlsPacketIn, SecretUpdate, TrafficSecrets},
 };
 
+pub use openmls_provider::Provider;
+pub(crate) use state_machine::ClientHandshakeState;
 pub use state_machine::HandshakeError;
 
 mod messages;
@@ -209,7 +211,7 @@ impl CompletedHandshake for MlsHandshake {
         match &self.state {
             MlsHandshakeState::None => (),
             MlsHandshakeState::Client(client_handshake_state) => {
-                client_handshake_state.delete(&mut connection)?;
+                ClientHandshakeState::delete(&mut connection, client_handshake_state.profile_id)?;
             }
             MlsHandshakeState::Server(server_handshake_state) => {
                 server_handshake_state.mls_session.delete(&connection)?;

--- a/src/mls_handshake/mod.rs
+++ b/src/mls_handshake/mod.rs
@@ -8,7 +8,7 @@ use openmls_rust_crypto::RustCrypto;
 use openmls_sqlite_storage::{Codec, Connection, SqliteStorageProvider};
 use openmls_traits::OpenMlsProvider;
 use state_machine::{
-    client::ClientHandshake,
+    client::{ClientHandshake, ClientHandshakeState},
     initialize_storage,
     server::{ServerHandshake, ServerHandshakeState},
 };
@@ -25,7 +25,6 @@ use crate::{
 };
 
 pub use openmls_provider::Provider;
-pub(crate) use state_machine::ClientHandshakeState;
 pub use state_machine::HandshakeError;
 
 mod messages;
@@ -121,9 +120,10 @@ impl Handshake for MlsHandshake {
         client_id: Uuid,
         server_verifying_key: &[u8],
     ) -> Result<TrafficSecrets, MlsHandshakeError> {
-        let connection = self.connection.lock().await;
+        let mut connection = self.connection.lock().await;
 
         ClientHandshakeState::create_table(&connection)?;
+        ClientHandshakeState::delete(&mut connection, client_id)?;
 
         // TODO: Check here if we can load a `ClientHandshakeState` from the database
         // and resume the handshake.

--- a/src/mls_handshake/openmls_provider.rs
+++ b/src/mls_handshake/openmls_provider.rs
@@ -19,7 +19,7 @@ impl Codec for JsonCodec {
     }
 }
 
-pub(super) struct Provider<ConnectionRef: Borrow<Connection>> {
+pub struct Provider<ConnectionRef: Borrow<Connection>> {
     crypto: RustCrypto,
     storage: SqliteStorageProvider<JsonCodec, ConnectionRef>,
 }

--- a/src/mls_handshake/persistence.rs
+++ b/src/mls_handshake/persistence.rs
@@ -102,7 +102,7 @@ impl ClientHandshakeState {
     }
 
     /// Delete the handshake state and the underlying MLS group state from the database.
-    pub(crate) fn delete(
+    pub(super) fn delete(
         connection: &mut Connection,
         profile_id: Uuid,
     ) -> Result<(), HandshakeError> {

--- a/src/mls_handshake/persistence.rs
+++ b/src/mls_handshake/persistence.rs
@@ -77,7 +77,7 @@ impl ClientHandshakeState {
         profile_id: Uuid,
     ) -> Result<Option<Self>, HandshakeError> {
         let mut stmt = connection.prepare(
-            "SELECT (handshake_state, version) FROM handshake_states WHERE profile_id = ?",
+            "SELECT handshake_state, version FROM handshake_states WHERE profile_id = ?",
         )?;
         let result = stmt
             .query_row([profile_id], |row| {
@@ -102,13 +102,16 @@ impl ClientHandshakeState {
     }
 
     /// Delete the handshake state and the underlying MLS group state from the database.
-    pub(super) fn delete(&self, connection: &mut Connection) -> Result<(), HandshakeError> {
-        if let Some(state) = Self::load(connection, self.profile_id)? {
+    pub(crate) fn delete(
+        connection: &mut Connection,
+        profile_id: Uuid,
+    ) -> Result<(), HandshakeError> {
+        if let Some(state) = Self::load(connection, profile_id)? {
             state.mls_session().delete(connection)?;
 
             connection.execute(
                 "DELETE FROM handshake_states WHERE profile_id = ?",
-                params![self.profile_id],
+                params![profile_id],
             )?;
         }
         Ok(())

--- a/src/mls_handshake/state_machine/client.rs
+++ b/src/mls_handshake/state_machine/client.rs
@@ -153,7 +153,7 @@ enum ClientInternalState {
 /// WARNING: When changing this struct, make sure to add a new
 /// `ClientHandshakeStateVersion` in the `persistence` module.
 #[derive(Serialize, Deserialize)]
-pub(in crate::mls_handshake) struct ClientHandshakeState {
+pub(crate) struct ClientHandshakeState {
     pub(crate) profile_id: Uuid,
     mls_session: MlsSession,
     internal_state: ClientInternalState,

--- a/src/mls_handshake/state_machine/mod.rs
+++ b/src/mls_handshake/state_machine/mod.rs
@@ -36,7 +36,6 @@ pub(super) mod server;
 #[cfg(test)]
 pub(super) mod tests;
 
-pub(crate) use client::ClientHandshakeState;
 pub(super) use mls_group::MlsSession;
 
 const CIPHERSUITE: Ciphersuite = Ciphersuite::MLS_256_XWING_AES256GCM_SHA512_P384;

--- a/src/mls_handshake/state_machine/mod.rs
+++ b/src/mls_handshake/state_machine/mod.rs
@@ -36,6 +36,7 @@ pub(super) mod server;
 #[cfg(test)]
 pub(super) mod tests;
 
+pub(crate) use client::ClientHandshakeState;
 pub(super) use mls_group::MlsSession;
 
 const CIPHERSUITE: Ciphersuite = Ciphersuite::MLS_256_XWING_AES256GCM_SHA512_P384;

--- a/src/pre_handshake/mod.rs
+++ b/src/pre_handshake/mod.rs
@@ -16,31 +16,31 @@ use crate::{
 pub mod psk;
 pub mod x25519;
 
+/// Result of the pre-handshake between a client and a server.
+pub struct HandshakePayload {
+    /// Shared secret established during the handshake between the client and the server
+    pub shared_secret: Vec<u8>,
+    /// Optional session ID negotiated between the client and the server
+    pub session_id: Option<Uuid>,
+}
+
 #[trait_variant::make(Send)]
 pub trait PreHandshake {
     type Error: std::error::Error + Send + Sync + 'static;
 
     fn initialize_storage(connection: &mut Connection) -> Result<(), Self::Error>;
 
-    /// Perform the handshake with the peer and return the key material and session ID.
-    ///
-    /// The session ID is used to identify the client/server or both. It can be unique or stable
-    /// between handshakes.
     async fn client_handshake<W: AsyncWrite + Send + Unpin, R: AsyncRead + Send + Unpin>(
         &mut self,
         rx: &mut R,
         tx: &mut W,
-    ) -> Result<(Vec<u8>, Uuid), Self::Error>;
+    ) -> Result<HandshakePayload, Self::Error>;
 
-    /// Perform the handshake with the peer and return the key material and session ID.
-    ///
-    /// The session ID is used to identify the client/server or both. It can be unique or stable
-    /// between handshakes.
     async fn server_handshake<W: AsyncWrite + Send + Unpin, R: AsyncRead + Send + Unpin>(
         &mut self,
         rx: &mut R,
         tx: &mut W,
-    ) -> Result<(Vec<u8>, Uuid), Self::Error>;
+    ) -> Result<HandshakePayload, Self::Error>;
 }
 
 pub(crate) fn derive_traffic_secrets(base_secret: &[u8]) -> Result<TrafficSecrets, CryptoError> {

--- a/src/pre_handshake/mod.rs
+++ b/src/pre_handshake/mod.rs
@@ -6,6 +6,7 @@ use openmls_rust_crypto::OpenMlsRustCrypto;
 use openmls_traits::{crypto::OpenMlsCrypto, types::CryptoError, OpenMlsProvider};
 use rusqlite::Connection;
 use tokio::io::{AsyncRead, AsyncWrite};
+use uuid::Uuid;
 
 use crate::{
     encryption_provider::KEY_SCHEDULE_HASH_FUNCTION,
@@ -21,18 +22,25 @@ pub trait PreHandshake {
 
     fn initialize_storage(connection: &mut Connection) -> Result<(), Self::Error>;
 
-    /// Perform the handshake with the peer and return the key material.
+    /// Perform the handshake with the peer and return the key material and session ID.
+    ///
+    /// The session ID is used to identify the client/server or both. It can be unique or stable
+    /// between handshakes.
     async fn client_handshake<W: AsyncWrite + Send + Unpin, R: AsyncRead + Send + Unpin>(
         &mut self,
         rx: &mut R,
         tx: &mut W,
-    ) -> Result<Vec<u8>, Self::Error>;
+    ) -> Result<(Vec<u8>, Uuid), Self::Error>;
 
+    /// Perform the handshake with the peer and return the key material and session ID.
+    ///
+    /// The session ID is used to identify the client/server or both. It can be unique or stable
+    /// between handshakes.
     async fn server_handshake<W: AsyncWrite + Send + Unpin, R: AsyncRead + Send + Unpin>(
         &mut self,
         rx: &mut R,
         tx: &mut W,
-    ) -> Result<Vec<u8>, Self::Error>;
+    ) -> Result<(Vec<u8>, Uuid), Self::Error>;
 }
 
 pub(crate) fn derive_traffic_secrets(base_secret: &[u8]) -> Result<TrafficSecrets, CryptoError> {

--- a/src/pre_handshake/psk.rs
+++ b/src/pre_handshake/psk.rs
@@ -29,15 +29,15 @@ impl PreHandshake for Psk {
         &mut self,
         _rx: &mut R,
         _tx: &mut W,
-    ) -> Result<Vec<u8>, Self::Error> {
-        Ok(self.key.clone())
+    ) -> Result<(Vec<u8>, Uuid), Self::Error> {
+        Ok((self.key.clone(), Uuid::nil()))
     }
 
     async fn server_handshake<W: AsyncWrite + Unpin, R: AsyncRead + Unpin>(
         &mut self,
         _rx: &mut R,
         _tx: &mut W,
-    ) -> Result<Vec<u8>, Self::Error> {
-        Ok(self.key.clone())
+    ) -> Result<(Vec<u8>, Uuid), Self::Error> {
+        Ok((self.key.clone(), Uuid::nil()))
     }
 }

--- a/src/pre_handshake/psk.rs
+++ b/src/pre_handshake/psk.rs
@@ -29,15 +29,21 @@ impl PreHandshake for Psk {
         &mut self,
         _rx: &mut R,
         _tx: &mut W,
-    ) -> Result<(Vec<u8>, Uuid), Self::Error> {
-        Ok((self.key.clone(), Uuid::nil()))
+    ) -> Result<HandshakePayload, Self::Error> {
+        Ok(HandshakePayload {
+            shared_secret: self.key.clone(),
+            session_id: None,
+        })
     }
 
     async fn server_handshake<W: AsyncWrite + Unpin, R: AsyncRead + Unpin>(
         &mut self,
         _rx: &mut R,
         _tx: &mut W,
-    ) -> Result<(Vec<u8>, Uuid), Self::Error> {
-        Ok((self.key.clone(), Uuid::nil()))
+    ) -> Result<HandshakePayload, Self::Error> {
+        Ok(HandshakePayload {
+            shared_secret: self.key.clone(),
+            session_id: None,
+        })
     }
 }

--- a/src/pre_handshake/x25519.rs
+++ b/src/pre_handshake/x25519.rs
@@ -6,8 +6,9 @@ use rand_chacha::ChaCha20Rng;
 use rand_core::{OsRng, SeedableRng as _};
 use thiserror::Error;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
-use uuid::Uuid;
 use x25519_dalek::{EphemeralSecret, PublicKey};
+
+use crate::pre_handshake::HandshakePayload;
 
 use super::PreHandshake;
 
@@ -36,7 +37,7 @@ impl PreHandshake for X25519Handshake {
         &mut self,
         rx: &mut R,
         tx: &mut W,
-    ) -> Result<(Vec<u8>, Uuid), Self::Error> {
+    ) -> Result<HandshakePayload, Self::Error> {
         let mut rng = ChaCha20Rng::from_rng(OsRng)?;
         let private_key = EphemeralSecret::random_from_rng(&mut rng);
 
@@ -50,14 +51,17 @@ impl PreHandshake for X25519Handshake {
         let server_pk = server_pk_bytes.into();
         let shared_secret = private_key.diffie_hellman(&server_pk);
 
-        Ok((shared_secret.to_bytes().to_vec(), Uuid::nil()))
+        Ok(HandshakePayload {
+            shared_secret: shared_secret.to_bytes().to_vec(),
+            session_id: None,
+        })
     }
 
     async fn server_handshake<W: AsyncWrite + Unpin, R: AsyncRead + Unpin>(
         &mut self,
         rx: &mut R,
         tx: &mut W,
-    ) -> Result<(Vec<u8>, Uuid), Self::Error> {
+    ) -> Result<HandshakePayload, Self::Error> {
         let mut client_pk_bytes = [0u8; X25519_PUBLIC_KEY_LENGTH];
         rx.read_exact(&mut client_pk_bytes).await?;
         let client_pk = client_pk_bytes.into();
@@ -70,6 +74,9 @@ impl PreHandshake for X25519Handshake {
 
         let shared_secret = private_key.diffie_hellman(&client_pk);
 
-        Ok((shared_secret.to_bytes().to_vec(), Uuid::nil()))
+        Ok(HandshakePayload {
+            shared_secret: shared_secret.to_bytes().to_vec(),
+            session_id: None,
+        })
     }
 }

--- a/src/pre_handshake/x25519.rs
+++ b/src/pre_handshake/x25519.rs
@@ -6,6 +6,7 @@ use rand_chacha::ChaCha20Rng;
 use rand_core::{OsRng, SeedableRng as _};
 use thiserror::Error;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use uuid::Uuid;
 use x25519_dalek::{EphemeralSecret, PublicKey};
 
 use super::PreHandshake;
@@ -35,7 +36,7 @@ impl PreHandshake for X25519Handshake {
         &mut self,
         rx: &mut R,
         tx: &mut W,
-    ) -> Result<Vec<u8>, Self::Error> {
+    ) -> Result<(Vec<u8>, Uuid), Self::Error> {
         let mut rng = ChaCha20Rng::from_rng(OsRng)?;
         let private_key = EphemeralSecret::random_from_rng(&mut rng);
 
@@ -49,14 +50,14 @@ impl PreHandshake for X25519Handshake {
         let server_pk = server_pk_bytes.into();
         let shared_secret = private_key.diffie_hellman(&server_pk);
 
-        Ok(shared_secret.to_bytes().to_vec())
+        Ok((shared_secret.to_bytes().to_vec(), Uuid::nil()))
     }
 
     async fn server_handshake<W: AsyncWrite + Unpin, R: AsyncRead + Unpin>(
         &mut self,
         rx: &mut R,
         tx: &mut W,
-    ) -> Result<Vec<u8>, Self::Error> {
+    ) -> Result<(Vec<u8>, Uuid), Self::Error> {
         let mut client_pk_bytes = [0u8; X25519_PUBLIC_KEY_LENGTH];
         rx.read_exact(&mut client_pk_bytes).await?;
         let client_pk = client_pk_bytes.into();
@@ -69,6 +70,6 @@ impl PreHandshake for X25519Handshake {
 
         let shared_secret = private_key.diffie_hellman(&client_pk);
 
-        Ok(shared_secret.to_bytes().to_vec())
+        Ok((shared_secret.to_bytes().to_vec(), Uuid::nil()))
     }
 }


### PR DESCRIPTION
Also 
* Return pre-handshake session ID from pre-handshake trait.
* Delete handshake state before client handshake (hack)